### PR TITLE
Fix example of invalid layout.

### DIFF
--- a/lib/Term/Tmux/Layout.pm
+++ b/lib/Term/Tmux/Layout.pm
@@ -90,7 +90,7 @@ the following would be invalid:
 
   1122
   1134
-  5556
+  5554
 
 Tmux divides the entire screen up either horizontally or vertically.
 However, there is no single horizontal or vertical split that would


### PR DESCRIPTION
Reading through the docs I noticed that the example of an invalid layout isn't actually invalid. (This was a little confusing to me as I tried to understand what was invalid about it.)

It looks like you'd already fixed the docs in `tmuxlayout`; this just applies the same change to the module itself.